### PR TITLE
Set b:undo_ftplugin

### DIFF
--- a/ftplugin/pbtxt.vim
+++ b/ftplugin/pbtxt.vim
@@ -15,6 +15,8 @@ set cpo&vim
 
 setlocal commentstring=#\ %s
 
+let b:undo_ftplugin = "setlocal cms<"
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 


### PR DESCRIPTION
Filetype plugins should generally reset any options they've changed by setting b:undo_ftplugin.  This is then executed when changing filetypes for the current buffer.

See: `:help undo_ftplugin`